### PR TITLE
update trx01 qaqc flags for automated qaqc

### DIFF
--- a/run/trx01.r
+++ b/run/trx01.r
@@ -88,8 +88,8 @@ try({
     nd <- lgr_ugga_qaqc()
     
     # trx01 lgr ugga automated qaqc
-    nd$QAQC_Flag[with(nd, CO2d_ppm < 300 | CO2d_ppm > 5000)] <- -111
-    nd$QAQC_Flag[with(nd, CH4d_ppm < 1 | CH4d_ppm > 100)] <- -112
+    nd$QAQC_Flag[with(nd, CO2d_ppm < 300 | CO2d_ppm > 5000)] <- -1
+    nd$QAQC_Flag[with(nd, CH4d_ppm < 1 | CH4d_ppm > 100)] <- -1
     
     update_archive(nd, data_path(site, instrument, 'qaqc'))
     nd <- lgr_ugga_calibrate()


### PR DESCRIPTION
Currently, QAQC flags are set as -111 and -112 if CO2 or CH4 are outside a set range, respectively. These flags are not mentioned in the pipeline README. I propose that they should be changed to -1 (data manually removed), which is generally used by the bad_data_fix.r script, but I think would fit for this situation.