### PR TITLE
sort qaqc files on time: fixes -9 flag

### DIFF
--- a/src/licor_6262_calibrate.r
+++ b/src/licor_6262_calibrate.r
@@ -26,7 +26,8 @@ licor_6262_calibrate <- function() {
   colnames(cal) <- data_config[[instrument]]$calibrated$col_names
   
   # Set QAQC flag giving priority to calibration QAQC then initial QAQC
-  cal$QAQC_Flag[cal$QAQC_Flag == 0] <- nd$QAQC_Flag[cal$QAQC_Flag == 0]
+  mask <- cal$QAQC_Flag == 0 | is.na(cal$QAQC_Flag)
+  cal$QAQC_Flag[mask] <- nd$QAQC_Flag[mask]
   
   if (nrow(cal) != nrow(nd))
     stop('Calibration script returned wrong number of records at: ', site)

--- a/src/licor_6262_qaqc.r
+++ b/src/licor_6262_qaqc.r
@@ -3,6 +3,9 @@ licor_6262_qaqc <- function() {
   # Invalidate columns containing record number and redundant datetime fields
   nd[, 2:7] <- NULL
   colnames(nd) <- data_config[[instrument]]$qaqc$col_names[1:ncol(nd)]
+  
+  # Sort dataframe by time
+  nd <- nd[order(nd$Time_UTC), ]
 
   # Initialize qaqc flag
   nd$QAQC_Flag <- 0
@@ -26,8 +29,9 @@ licor_6262_qaqc <- function() {
   nd$QAQC_Flag[analog_mask] <- 1
   nd$QAQC_Flag[with(nd, Flow_mLmin < 395 | Flow_mLmin > 405)] <- -4
   nd$QAQC_Flag[with(nd, ID_CO2 %in% c(-1, -2, -3, NA))] <- -3
+  nd$QAQC_Flag[with(nd, ID_CO2 != -99 & ID_CO2 != -10 & ID_CO2 < 0)] <- -3
   nd$QAQC_Flag[with(nd, ID_CO2 == -99)] <- -2
-  nd$QAQC_Flag[with(nd, ID_CO2 > 0)] <- -9
+  nd$QAQC_Flag[with(nd, ID_CO2 >= 0)] <- -9
   nd$QAQC_Flag[is_manual_qc] <- -1
 
   # Compute H2O concentration in ppm

--- a/src/licor_7000_qaqc.r
+++ b/src/licor_7000_qaqc.r
@@ -3,6 +3,9 @@ licor_7000_qaqc <- function() {
   # Invalidate columns containing record number and redundant datetime fields
   nd[, 2:7] <- NULL
   colnames(nd) <- data_config[[instrument]]$qaqc$col_names[1:ncol(nd)]
+  
+  # Sort dataframe by time
+  nd <- nd[order(nd$Time_UTC), ]
 
   # Initialize qaqc flag
   nd$QAQC_Flag <- 0
@@ -27,8 +30,9 @@ licor_7000_qaqc <- function() {
   #nd$QAQC_Flag[analog_mask] <- 1
   nd$QAQC_Flag[with(nd, Flow_mLmin < 395 | Flow_mLmin > 405)] <- -4
   nd$QAQC_Flag[with(nd, ID_CO2 %in% c(-1, -2, -3, NA))] <- -3
+  nd$QAQC_Flag[with(nd, ID_CO2 != -99 & ID_CO2 != -10 & ID_CO2 < 0)] <- -3
   nd$QAQC_Flag[with(nd, ID_CO2 == -99)] <- -2
-  nd$QAQC_Flag[with(nd, ID_CO2 > 0)] <- -9
+  nd$QAQC_Flag[with(nd, ID_CO2 >= 0)] <- -9
   nd$QAQC_Flag[is_manual_qc] <- -1
 
   # Compute H2O concentration in ppm


### PR DESCRIPTION
qaqc files were not sorted on time. This meant that when QAQC_Flag 's from the qaqc files were applied to the calibrated files, flags were assigned to the wrong times.