### PR TITLE
remove whitespace from ldf IDs

### DIFF
--- a/run/ldf.r
+++ b/run/ldf.r
@@ -51,6 +51,9 @@ try({
     nd$Time_UTC <- fastPOSIXct(nd$Time_UTC, tz = 'UTC')
     attributes(nd$Time_UTC)$tzone <- 'UTC'
     
+    # Remove whitespace from padded IDs
+    nd$ID < str_trim(nd$ID)
+    
     for (i in 3:ncol(nd)) {
       nd[[i]] <- suppressWarnings(as.numeric(nd[[i]]))
     }


### PR DESCRIPTION
IDs are too long for QAQC regex