### PR TITLE
read_pattern fix

### DIFF
--- a/run/ldf.r
+++ b/run/ldf.r
@@ -43,7 +43,7 @@ try({
     pattern <- c('/', 'e')
     
     nd <- read_pattern(selector, colnums, pattern)
-    if (nrow(nd) < 1) return(NULL)
+    if (is.null(nd) || nrow(nd) < 1) return(NULL)
     colnames(nd) <- c('Time_UTC', 'ID', 'CH4_ppm', 'CH4_ppm_sd',
                       'H2O_ppm', 'H2O_ppm_sd', 'CO2_ppm', 'CO2_ppm_sd', 'CH4d_ppm',
                       'CH4d_ppm_sd', 'CO2d_ppm', 'CO2d_ppm_sd', 'Cavity_P_torr',

--- a/run/trx01.r
+++ b/run/trx01.r
@@ -47,13 +47,9 @@ try({
     # e : exponent notation in LGR output
     pattern <- c('/', 'e')
 
-    # Read batch if it exists
-    tryCatch({
-      nd <- read_pattern(selector, colnums, pattern)
-        }, error = function(e) e)
-    if (inherits(nd, 'error')) next
+    nd <- read_pattern(selector, colnums, pattern)
              
-    if (nrow(nd) < 1) next
+    if (is.null(nd) || nrow(nd) < 1) next
     colnames(nd) <- c('Time_UTC', 'ID', 'CH4_ppm', 'H2O_ppm', 'CO2_ppm', 
                       'CH4d_ppm', 'CO2d_ppm', 'Cavity_P_torr', 'Cavity_T_C', 
                       'Ambient_T_C', 'RD0_us', 'RD1_us')
@@ -136,7 +132,7 @@ try({
     pattern <- c('GPGGA', '[*]')
     
     nd <- read_pattern(selector, colnums, pattern)
-    if (nrow(nd) < 1) next
+    if (is.null(nd) || nrow(nd) < 1) next
     nd <- nd %>%
       setNames(c('Time_UTC', 'GPS_Time_UTC', 'Lati_deg', 'Long_deg',
                  'Fix_Quality', 'NSat', 'Location_Uncertainty_m',
@@ -202,7 +198,7 @@ try({
     pattern <- c('/', '-v e')
     
     nd <- read_pattern(selector, colnums, pattern)
-    if (nrow(nd) < 1) next
+    if (is.null(nd) || nrow(nd) < 1) next
     nd <- nd %>%
       setNames(c('Time_UTC', 'O3_ppb', 'Cavity_T_C', 'Cavity_P_hPa', 
                  'Flow_ccmin'))

--- a/run/wbb.r
+++ b/run/wbb.r
@@ -33,7 +33,9 @@ try({
   }
   colnums <- c(1:6, 8)
   pattern <- '[*]'
-  nd <- read_pattern(selector, colnums, pattern) %>%
+  nd <- read_pattern(selector, colnums, pattern) 
+  if (is.null(nd) || nrow(nd) < 1) return(NULL)
+  nd <- nd %>%
     add_column(RECORD = NA, batt_volt_Min = NA, PTemp_Avg = NA, .after = 'V1') %>%
     setNames(data_config$metone_es642$raw$col_names) %>%
     mutate_at(vars(PM_25_Avg:BP_Avg), funs(suppressWarnings(as.numeric(.)))) %>%

--- a/src/read_pattern.r
+++ b/src/read_pattern.r
@@ -34,5 +34,8 @@ read_pattern <- function(selector, colnums = NULL, pattern = NULL, ...) {
   cmd <- paste('cat', selector, sed_cmd, iconv_cmd, grep_cmd, cut_cmd)
   con <- pipe(cmd, 'r')
   on.exit(close(con))
-  breakstr(readLines(con, skipNul = T))
+  
+  strings <-readLines(con, skipNul = T)
+  if (length(strings) == 0) return(NULL)
+  breakstr(strings)
 }


### PR DESCRIPTION
Something seems to have broken, likely during a CHPC upgrade. No major codes changes have been made to the read_pattern process in the past 5 years. Previously, when the grep-like selector string did not have any matches using the unix cat command, read_pattern would return an object capable of applying the function nrows.
```
nd <- read_pattern(selector, colnums, pattern)
if (nrow(nd) < 1) next
```
Now, however, read_pattern crashes on a dplyr line within the uataq function breakstr. To avoid editing the uataq package, I have made read_pattern return Null if the result of the cat command is an empty character string. This is following the implementation of lgr_ugga_init.r